### PR TITLE
WP boilerplate composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "optimize-autoloader": true,
     "sort-packages": true,
     "platform": {
-      "php": "7.2"
+      "php": "7.4"
     }
   },
   "extra": {

--- a/upstream-config/composer.json
+++ b/upstream-config/composer.json
@@ -4,12 +4,28 @@
     "version": "1.0.0",
     "repositories": [
         {
+            "type": "package",
+            "package": {
+                "name": "advanced-custom-fields/advanced-custom-fields-pro",
+                "version": "5.9.3",
+                "type": "wordpress-plugin",
+                "dist": {
+                "type": "zip",
+                "url": "https://connect.advancedcustomfields.com/index.php?a=download&p=pro&k={%PLUGIN_ACF_KEY}&t={%version}"
+                },
+                "require": {
+                "composer/installers": "^1.4",
+                "ffraenz/private-composer-installer": "^5.0"
+                }
+        }
+        },
+          {
             "type": "composer",
             "url": "https://wpackagist.org"
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "composer/installers": "^1.3.0",
         "pantheon-systems/quicksilver-pushback": "^2",
         "pantheon-systems/wordpress-composer": "*",
@@ -18,8 +34,15 @@
         "wpackagist-plugin/lh-hsts": "^1.24",
         "wpackagist-plugin/pantheon-advanced-page-cache": ">=0.3.0",
         "wpackagist-plugin/wp-native-php-sessions": ">=0.6.9",
-        "wpackagist-theme/twentynineteen": "^1.2",
-        "wp-coding-standards/wpcs": "^1.2.1"
+        "wpackagist-theme/twentynineteen": "^2.2",
+        "wp-coding-standards/wpcs": "^1.2.1",
+        "timber/timber": "1.*",
+        "advanced-custom-fields/advanced-custom-fields-pro": "^5.0.0",
+        "wpackagist-plugin/classic-editor": "^1.6",
+        "wpackagist-plugin/wordpress-seo": "^17.2",
+        "wpackagist-plugin/acf-content-analysis-for-yoast-seo": "^3.0",
+        "wpackagist-plugin/svg-support": "^2.3",
+        "wpackagist-plugin/acf-better-search": "^4.0"
     },
     "require-dev": {
         "behat/mink-goutte-driver": "^1.2.1",


### PR DESCRIPTION
update to pantheon's boilerplate to include punk'ave dependencies. Still need to automate the ACF key and include theme.